### PR TITLE
Remove reported filePaths from serial report after yielding

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -85,6 +85,7 @@ export async function* serialReport(
       const sizes = context.compressed.get(filePath);
       if (sizes !== undefined && sizes?.[0][0] && sizes?.[1][0] && sizes?.[2][0]) {
         yield [filePath, sizes?.[0][0], sizes?.[1][0], sizes?.[2][0]];
+        paths.delete(filePath);
       }
     }
     next = await compressResults.next();


### PR DESCRIPTION
Before this change, when using `serialReport`, every time that the `compress` function* yields, the `serialReport` function* will iterate the entire set of files, and report all of the ones that have been calculated. This means that every time, it'll yield more and more duplicates.

This PR fixes the issue by removing filePaths that were yielded (with their sizes) from the set of files that still need to be reported