### PR TITLE
Add -c config option for users preferring to avoid package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Each file (key in the filesize object) must include an object with key/value pai
 
 **After completing configuration**, invoke `filesize` via: `yarn filesize`. 
 
-Optionally one can target a different project directory via the `p` parameter `yarn filesize -p={PATH}`.
+Optionally one can target a different project directory via the `p` parameter `yarn filesize -p={PATH}`, or a different configuration file via the `c` parameter `yarn filesize -c=${PATH/filesize.json}`.
 
 ### Track Resource Size
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import * as path from 'path';
 import Project from './validation/Project';
 import Config from './validation/Config';
 import { Context, FileModifier, SizeMap } from './validation/Condition';
@@ -22,14 +23,23 @@ import { Report } from './log/report';
 export { Report } from './log/report';
 
 export async function report(
-  projectPath: string,
+  configOrProjectPath: string,
   fileModifier: FileModifier,
   report?: typeof Report,
 ): Promise<SizeMap> {
+  let projectPath = '';
+  let packagePath = '';
+  if (path.extname(configOrProjectPath) === '.json') {
+    // The requested config or project path is a config.
+    packagePath = configOrProjectPath;
+  } else {
+    projectPath = configOrProjectPath;
+  }
+
   const conditions = [Project, Config];
   let context: Context = {
     projectPath,
-    packagePath: '',
+    packagePath,
     packageContent: '',
     silent: true,
     originalPaths: new Map(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,19 +27,19 @@ import { TTYReport } from './log/tty-report';
 import { NoTTYReport } from './log/no-tty-report';
 
 const args = mri(process.argv.slice(2), {
-  alias: { p: 'project' },
-  default: { project: process.cwd(), silent: false },
+  alias: { p: 'project', c: 'config' },
+  default: { project: process.cwd(), config: '', silent: false },
 });
 
 /**
  * Read the configuration from the specified project, validate it, perform requested compression, and report the results.
  */
 (async function () {
-  const { project: projectPath, silent } = args;
+  const { project: projectPath, silent, config: requestedConfig } = args;
   const conditions = [Project, Config];
   const context: Context = {
     projectPath,
-    packagePath: '',
+    packagePath: requestedConfig,
     packageContent: '',
     silent,
     originalPaths: new Map(),

--- a/test/config-validation/config-validation.test.ts
+++ b/test/config-validation/config-validation.test.ts
@@ -15,7 +15,6 @@
  */
 
 import test from 'ava';
-import { exec } from 'child_process';
 import Config from '../../src/validation/Config';
 import { Context } from '../../src/validation/Condition';
 
@@ -101,7 +100,7 @@ test("missing maxSize from item in 'filesize' should fail", async (t) => {
   };
   const message = await Config(context)();
 
-  t.is(message, `Configuration for 'index.js' is invalid. (size unspecified)`);
+  t.is(message, "Configuration for 'index.js' is invalid. (size unspecified)");
 });
 
 test("missing compression from item in 'filesize' should fail", async (t) => {
@@ -118,14 +117,39 @@ test("missing compression from item in 'filesize' should fail", async (t) => {
   };
   const message = await Config(context)();
 
-  t.is(message, `Configuration for 'index.js' is invalid. (compression values unspecified)`);
+  t.is(message, "Configuration for 'index.js' is invalid. (compression values unspecified)");
 });
 
-test.cb('standalone configuration file when valid should pass', (t) => {
-  const executeSuccess = exec('./dist/filesize -c=test/config-validation/fixtures/standalone-config/filesize.json');
+test('standalone configuration file when valid should pass', async (t) => {
+  const context: Context = {
+    packagePath: 'test/config-validation/fixtures/standalone-config/filesize.json',
+    projectPath: '',
+    packageContent: '',
+    originalPaths: new Map(),
+    compressed: new Map(),
+    comparison: new Map(),
+    silent: false,
+    fileModifier: null,
+    fileContents: new Map(),
+  };
+  const message = await Config(context)();
 
-  executeSuccess.on('exit', (code) => {
-    t.is(code, 0);
-    t.end();
-  });
+  t.is(message, null);
+});
+
+test('standalone configuration file when path is invalid should fail', async (t) => {
+  const context: Context = {
+    packagePath: 'test/config-validation/fixtures/standalone-config/invalid.json',
+    projectPath: '',
+    packageContent: '',
+    originalPaths: new Map(),
+    compressed: new Map(),
+    comparison: new Map(),
+    silent: false,
+    fileModifier: null,
+    fileContents: new Map(),
+  };
+  const message = await Config(context)();
+
+  t.is(message, `Could not read the configuration in '${context.packagePath}'`);
 });

--- a/test/config-validation/config-validation.test.ts
+++ b/test/config-validation/config-validation.test.ts
@@ -15,6 +15,7 @@
  */
 
 import test from 'ava';
+import { exec } from 'child_process';
 import Config from '../../src/validation/Config';
 import { Context } from '../../src/validation/Condition';
 
@@ -118,4 +119,13 @@ test("missing compression from item in 'filesize' should fail", async (t) => {
   const message = await Config(context)();
 
   t.is(message, `Configuration for 'index.js' is invalid. (compression values unspecified)`);
+});
+
+test.cb('standalone configuration file when valid should pass', (t) => {
+  const executeSuccess = exec('./dist/filesize -c=test/config-validation/fixtures/standalone-config/filesize.json');
+
+  executeSuccess.on('exit', (code) => {
+    t.is(code, 0);
+    t.end();
+  });
 });

--- a/test/config-validation/fixtures/standalone-config/filesize.json
+++ b/test/config-validation/fixtures/standalone-config/filesize.json
@@ -1,0 +1,5 @@
+{
+  "filesize": {
+    "track": ["test/config-validation/fixtures/standalone-config/**/*.js"]
+  }
+}

--- a/test/config-validation/fixtures/standalone-config/index.js
+++ b/test/config-validation/fixtures/standalone-config/index.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2020 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */

--- a/test/end-to-end/fixtures/api-report/filesize.json
+++ b/test/end-to-end/fixtures/api-report/filesize.json
@@ -1,0 +1,6 @@
+{
+  "filesize": {
+    "track": ["test/end-to-end/fixtures/api-report/**/*.js"],
+    "trackFormat": ["brotli"]
+  }
+}

--- a/test/end-to-end/fixtures/item-too-large/filesize.json
+++ b/test/end-to-end/fixtures/item-too-large/filesize.json
@@ -1,0 +1,24 @@
+{
+  "filesize": {
+    "dist/index.js": {
+      "brotli": "15 kB",
+      "gzip": "20 kB",
+      "none": "500 kB"
+    },
+    "dist/foo.js": {
+      "brotli": "15 kB",
+      "gzip": "20 kB",
+      "none": "500 kB"
+    },
+    "dist/bar.js": {
+      "brotli": "15 kB",
+      "gzip": "20 kB",
+      "none": "500 kB"
+    },
+    "dist/baz.js": {
+      "brotli": "15 kB",
+      "gzip": "20 kB",
+      "none": "500 kB"
+    }
+  }
+}

--- a/test/end-to-end/fixtures/missing-item/filesize.json
+++ b/test/end-to-end/fixtures/missing-item/filesize.json
@@ -1,0 +1,7 @@
+{
+  "filesize": {
+    "index.js": {
+      "none": "500 kB"
+    }
+  }
+}

--- a/test/end-to-end/fixtures/successful/filesize.json
+++ b/test/end-to-end/fixtures/successful/filesize.json
@@ -1,0 +1,9 @@
+{
+  "filesize": {
+    "index.js": {
+      "brotli": "3.5 kB",
+      "gzip": "4 kB",
+      "none": "10 kB"
+    }
+  }
+}

--- a/test/end-to-end/successful.test.ts
+++ b/test/end-to-end/successful.test.ts
@@ -20,10 +20,17 @@ import { report, Report } from '../../src/api';
 import { SizeMapValue, SizeMap } from '../../src/validation/Condition';
 import { resolve, relative } from 'path';
 
-const toReport = 'test/end-to-end/fixtures/successful';
-
 test.cb('item under requested filesize limit passes', (t) => {
   const executeSuccess = exec('./dist/filesize -p=test/end-to-end/fixtures/successful');
+
+  executeSuccess.on('exit', (code) => {
+    t.is(code, 0);
+    t.end();
+  });
+});
+
+test.cb('standalone configuration file when valid should pass', (t) => {
+  const executeSuccess = exec('./dist/filesize -c=test/end-to-end/fixtures/successful/filesize.json');
 
   executeSuccess.on('exit', (code) => {
     t.is(code, 0);
@@ -40,7 +47,20 @@ test('item under requested filesize limit passes from API', async (t) => {
   const expected: SizeMap = new Map();
   expected.set(resolve('test/end-to-end/fixtures/successful/index.js'), sizes);
 
-  const results = await report(toReport, null);
+  const results = await report('test/end-to-end/fixtures/successful', null);
+  t.deepEqual(results, expected);
+});
+
+test('item under requested filesize limit passes from API, using configuration file', async (t) => {
+  const sizes: SizeMapValue = [
+    [3410, 3584], // brotli
+    [3737, 4096], // gzip
+    [9327, 10240], // none
+  ];
+  const expected: SizeMap = new Map();
+  expected.set(resolve('test/end-to-end/fixtures/successful/index.js'), sizes);
+
+  const results = await report('test/end-to-end/fixtures/successful/filesize.json', null);
   t.deepEqual(results, expected);
 });
 
@@ -53,12 +73,24 @@ test('item under requested filesize limit passes from API, with replacement', as
   const expected: SizeMap = new Map();
   expected.set(resolve('test/end-to-end/fixtures/successful/index.js'), sizes);
 
-  const results = await report(toReport, (content) => content.replace(new RegExp('preact.umd.js.map', 'g'), 'FOO.map'));
+  const results = await report('test/end-to-end/fixtures/successful', (content) => content.replace(new RegExp('preact.umd.js.map', 'g'), 'FOO.map'));
+  t.deepEqual(results, expected);
+});
+
+test('item under requested filesize limit passes from API, using configuration file, with replacement', async (t) => {
+  const sizes: SizeMapValue = [
+    [3401, 3584], // brotli
+    [3731, 4096], // gzip
+    [9317, 10240], // none
+  ];
+  const expected: SizeMap = new Map();
+  expected.set(resolve('test/end-to-end/fixtures/successful/index.js'), sizes);
+
+  const results = await report('test/end-to-end/fixtures/successful/filesize.json', (content) => content.replace(new RegExp('preact.umd.js.map', 'g'), 'FOO.map'));
   t.deepEqual(results, expected);
 });
 
 test('api is interactive with custom reporter', async (t) => {
-  const toReport = 'test/end-to-end/fixtures/api-report';
   const mapping = new Map([
     ['preact.js', 3477],
     ['inferno.js', 7297],
@@ -73,7 +105,31 @@ test('api is interactive with custom reporter', async (t) => {
         const completed = super.getUpdated(context);
         for (const complete of completed) {
           const [filePath, sizeMap] = complete;
-          const relativePath = relative(toReport, filePath);
+          const relativePath = relative('test/end-to-end/fixtures/api-report', filePath);
+          t.is(mapping.has(relativePath), true);
+          t.is(mapping.get(relativePath), sizeMap[0][0]);
+        }
+      }
+    },
+  );
+});
+
+test('api is interactive with custom reporter, using configuration file', async (t) => {
+  const mapping = new Map([
+    ['preact.js', 3477],
+    ['inferno.js', 7297],
+    ['react-dom.js', 28721],
+  ]);
+
+  await report(
+    'test/end-to-end/fixtures/api-report/filesize.json',
+    (content) => content,
+    class extends Report {
+      update(context: any) {
+        const completed = super.getUpdated(context);
+        for (const complete of completed) {
+          const [filePath, sizeMap] = complete;
+          const relativePath = relative('test/end-to-end/fixtures/api-report', filePath);
           t.is(mapping.has(relativePath), true);
           t.is(mapping.get(relativePath), sizeMap[0][0]);
         }

--- a/test/end-to-end/throw-error.test.ts
+++ b/test/end-to-end/throw-error.test.ts
@@ -27,8 +27,26 @@ test.cb('item with missing file fails with exit code 5', (t) => {
   });
 });
 
+test.cb('item with missing file fails with exit code 5, using configuration file', (t) => {
+  const executeFailure = exec('./dist/filesize -c=test/end-to-end/fixtures/missing-item/filesize.json');
+
+  executeFailure.on('exit', (code) => {
+    t.is(code, 5);
+    t.end();
+  });
+});
+
 test.cb('too large valid item fails with exit code 6', (t) => {
   const executeFailure = exec('./dist/filesize -p=test/end-to-end/fixtures/item-too-large');
+
+  executeFailure.on('exit', (code) => {
+    t.is(code, 6);
+    t.end();
+  });
+});
+
+test.cb('too large valid item fails with exit code 6, using configuration file', (t) => {
+  const executeFailure = exec('./dist/filesize -c=test/end-to-end/fixtures/item-too-large/filesize.json');
 
   executeFailure.on('exit', (code) => {
     t.is(code, 6);
@@ -39,6 +57,14 @@ test.cb('too large valid item fails with exit code 6', (t) => {
 test('item with missing file throws exception from API', async (t) => {
   try {
     await report('test/end-to-end/fixtures/missing-item', null);
+  } catch (e) {
+    t.is(e, `Configuration for 'index.js' is invalid. (path is not a valid file)`);
+  }
+});
+
+test('item with missing file throws exception from API, using configuration file', async (t) => {
+  try {
+    await report('test/end-to-end/fixtures/missing-item/filesize.json', null);
   } catch (e) {
     t.is(e, `Configuration for 'index.js' is invalid. (path is not a valid file)`);
   }


### PR DESCRIPTION
Items to complete

- [x] Support -c config in distributable
- [x] Support -c config in Node API.
- [x] Testing for success conditions
- [x] Testing for failure conditions