### PR TITLE
[Documentation] Fix gif resource path

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Uses native compression from Node Core, attempts to parallelize compression work across available CPUs, and requires Node >= `12`.
 
-![Interactive UI Processing Large Files](https://github.com/ampproject/filesize/raw/master/.github/preview.gif)
+![Interactive UI Processing Large Files](https://raw.githubusercontent.com/michaeljaltamirano/filesize/main/.github/preview.gif)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Uses native compression from Node Core, attempts to parallelize compression work across available CPUs, and requires Node >= `12`.
 
-![Interactive UI Processing Large Files](https://raw.githubusercontent.com/michaeljaltamirano/filesize/main/.github/preview.gif)
+![Interactive UI Processing Large Files](https://raw.githubusercontent.com/ampproject/filesize/main/.github/preview.gif)
 
 ## Installation
 


### PR DESCRIPTION
Hi,

I noticed the .gif link in the README appears to be broken. It looks related to changing the main branch name to `main`. This PR points to the raw resource accessed via the Github UI. 