### PR TITLE
Expose `NoTTYReport` and `silent` for use by `amphtml`

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -27,7 +27,7 @@ export async function report(
   configOrProjectPath: string,
   fileModifier: FileModifier,
   report?: typeof Report,
-  silent?: boolean,   
+  silent?: boolean,
 ): Promise<SizeMap> {
   let projectPath = '';
   let packagePath = '';


### PR DESCRIPTION
This will enable the `amphtml` bundle size check to replace its custom logging with what is built in to `filesize`

Companion PR to https://github.com/ampproject/amphtml/pull/32479
Addresses https://github.com/ampproject/amphtml/pull/32476#discussion_r571330400