### PR TITLE
Support Comparisons Officially

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ampproject/filesize",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Audit the filesize of items specified in package.json.",
   "author": "Kristofer Baxter",
   "license": "Apache-2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,14 +28,14 @@ import { NoTTYReport } from './log/no-tty-report';
 
 const args = mri(process.argv.slice(2), {
   alias: { p: 'project', c: 'config' },
-  default: { project: process.cwd(), config: '', silent: false },
+  default: { project: process.cwd(), config: '', silent: false, compare: '' },
 });
 
 /**
  * Read the configuration from the specified project, validate it, perform requested compression, and report the results.
  */
 (async function () {
-  const { project: projectPath, silent, config: requestedConfig } = args;
+  const { project: projectPath, silent, config: requestedConfig, compare } = args;
   const conditions = [Project, Config];
   const context: Context = {
     projectPath,
@@ -47,6 +47,7 @@ const args = mri(process.argv.slice(2), {
     compressed: new Map(),
     // Stores the basis of comparison.
     comparison: new Map(),
+    comparisonPath: compare,
     fileModifier: null,
     fileContents: new Map(),
   };

--- a/src/validation/Compare.ts
+++ b/src/validation/Compare.ts
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2021 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ConditionFunction, Context, SizeMap } from './Condition';
+import { isDirectory, isFile, readFile } from '../helpers/fs';
+import { resolve, dirname } from 'path';
+import { MakeError } from '../log/helpers/error';
+
+/**
+ * Ensure context contains a valid project directory and `package.json` inside.
+ * @param context
+ */
+const Compare: ConditionFunction = (context: Context) => {
+  return async function () {
+    if (context.comparisonPath !== '') {
+      // The comparison path was specified up front
+      if (!(await isFile(context.comparisonPath))) {
+        return MakeError(`comparison path specified '${context.comparisonPath}' doesn't exist, is this a valid comparison?`);
+      }
+
+      const comparisonFileContent = await readFile(context.comparisonPath);
+      if (comparisonFileContent === null) {
+        return MakeError(`comparison path specified '${context.comparisonPath}' appears invalid, does it have contents?`);
+      }
+
+      context.comparison = new Map(JSON.parse(comparisonFileContent)) as SizeMap;
+      // TODO: Likely need to do some validation on the contents to ensure its a SizeMap structure.
+    }
+
+    return null;
+    // if (context.packagePath !== '') {
+    //   // The package path was specified up front, its likely not a package.json
+    //   if (!(await isFile(context.packagePath))) {
+    //     return MakeError(`config specified '${context.packagePath}' doesn't exist, is this a valid project?`);
+    //   }
+    //   context.projectPath = dirname(context.packagePath);
+    //   return null;
+    // }
+
+    // const projectPath: string = resolve(context.projectPath);
+    // if (!(await isDirectory(projectPath))) {
+    //   return MakeError(`project specified '${context.projectPath}' doesn't exist, is this a valid project?`);
+    // }
+
+    // const packagePath = resolve(context.projectPath, 'package.json');
+    // if (!(await isFile(packagePath))) {
+    //   return MakeError(`Missing '${packagePath}', is this a valid project?`);
+    // }
+
+    // context.projectPath = projectPath;
+    // context.packagePath = packagePath;
+    // return null;
+  };
+};
+
+export default Compare;

--- a/src/validation/Condition.ts
+++ b/src/validation/Condition.ts
@@ -60,6 +60,8 @@ export interface Context {
   compressed: SizeMap;
   // Stores the basis of comparison.
   comparison: SizeMap;
+  // The filepath of a comparison map
+  comparisonPath: string;
   // Allows the API to specify a method that alters content before analysis.
   fileModifier: FileModifier;
   // Stores the contents of files, to avoid reading from disk per compression type.


### PR DESCRIPTION
This is an incomplete PR, but here's the plan:

1. Support loading a `SizeMap` comparison from the Filesystem via parameter and in the API.
2. Report the comparison delta in the UI, and in the output of the API.
3. Support Github artifacts for storage per merged commit.
4. Build Github Action helper to retrieve artifact for passing in via CLI.
5. Document the pattern for other CI systems, like CircleCI.